### PR TITLE
feat: contract with data types and basic functionalities in Solidity

### DIFF
--- a/DataTypes.sol
+++ b/DataTypes.sol
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+contract DataTypesExample {
+    // State variables
+    address public owner;
+    uint256 public integerValue;
+    bool public isActive;
+    string public message;
+
+    modifier onlyOwner() {
+        require(msg.sender == owner, "Only the owner can call this function");
+        _; // Continue execution if the requirement is met
+    }
+
+    // Constructor
+    constructor() {
+        owner = msg.sender;
+        integerValue = 42;
+        isActive = true;
+        message = "Hello, World!";
+    }
+
+    // Function using various data types
+    function updateMessage(string memory newMessage) public onlyOwner {
+        require(bytes(newMessage).length > 0, "Message cannot be empty");
+        
+        // Local variables
+        uint256 messageLength = bytes(message).length;
+        uint256 newMessageLength = bytes(newMessage).length;
+
+        // Update state variables
+        integerValue = newMessageLength;
+        isActive = !isActive;
+
+        // Control flow structure
+        if (messageLength < newMessageLength) {
+            message = newMessage;
+        } else {
+            revert("The new message is not longer");
+        }
+    }
+
+    // Read-only function that doesn't modify the state (using view)
+    function getMessageLength() public view returns (uint256) {
+        return bytes(message).length;
+    }
+}


### PR DESCRIPTION
Contract that demonstrates the use of various types of data, access modifier, and basic functionalities such as updating messages. The contract includes state variables, an `onlyOwner` modifier to restrict certain functions to the owner, a constructor for initialization, and two functions: `updateMessage` to change the message and `getMessageLength` to get the length of the message.